### PR TITLE
Remove unused imports

### DIFF
--- a/simplekeyvalue/models.py
+++ b/simplekeyvalue/models.py
@@ -1,8 +1,7 @@
 from django.db import models
-from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
 
 from .managers import KeyValueManager
+
 # Create your models here.
 
 class KeyValue(models.Model):


### PR DESCRIPTION
The generic  relations code has been moved/rearranged so this import doesn't work in Django 1.9 anyway.
